### PR TITLE
Check poll handle is active before attempting to stop and unreference it

### DIFF
--- a/socket_watcher.cpp
+++ b/socket_watcher.cpp
@@ -84,7 +84,7 @@ void SocketWatcher::Stop(const Nan::FunctionCallbackInfo<Value>& info)
 }
 
 void SocketWatcher::StopInternal() {
-  if (poll_ != NULL) {
+  if (poll_ != NULL && uv_is_active((uv_handle_t*)poll_)) {
     uv_poll_stop(poll_);
     Unref();
   }


### PR DESCRIPTION
If the stop method is inadvertently called twice, the second call results in the following error:

Assertion failed: (!persistent().IsWeak()), function Unref, file ../node_modules/nan/nan_object_wrap.h, line 107.

I believe it should return cleanly even if it is a no-op call.